### PR TITLE
Add unit test to openai

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/rakyll/openai-go
 
 go 1.19
+
+require github.com/stretchr/testify v1.8.2
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/openai.go
+++ b/openai.go
@@ -42,6 +42,10 @@ func NewSession(apiKey string) *Session {
 // session's API key. MakeRequest marshals input as the request body,
 // and unmarshals the response as output.
 func (s *Session) MakeRequest(ctx context.Context, endpoint string, input, output any) error {
+	if input == nil {
+		return fmt.Errorf("params cannot be nil")
+	}
+
 	buf, err := json.Marshal(input)
 	if err != nil {
 		return err
@@ -97,6 +101,7 @@ func (s *Session) sendRequest(req *http.Request, contentType string, output any)
 			Payload:    respBody,
 		}
 	}
+
 	return json.NewDecoder(resp.Body).Decode(output)
 }
 

--- a/openai.go
+++ b/openai.go
@@ -55,8 +55,8 @@ func (s *Session) MakeRequest(ctx context.Context, endpoint string, input, outpu
 	if err != nil {
 		return err
 	}
-
-	return s.sendRequest(req, "application/json", output)
+	s.setHeaders(req, "application/json")
+	return s.sendRequest(req, output)
 }
 
 // Upload makes a multi-part form data upload them with
@@ -73,10 +73,11 @@ func (s *Session) Upload(ctx context.Context, endpoint string, file io.Reader, f
 	if err != nil {
 		return err
 	}
-	return s.sendRequest(req, mw.FormDataContentType(), output)
+	s.setHeaders(req, mw.FormDataContentType())
+	return s.sendRequest(req, output)
 }
 
-func (s *Session) sendRequest(req *http.Request, contentType string, output any) error {
+func (s *Session) setHeaders(req *http.Request, contentType string) {
 	if s.apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+s.apiKey)
 	}
@@ -84,7 +85,9 @@ func (s *Session) sendRequest(req *http.Request, contentType string, output any)
 		req.Header.Set("OpenAI-Organization", s.OrganizationID)
 	}
 	req.Header.Set("Content-Type", contentType)
+}
 
+func (s *Session) sendRequest(req *http.Request, output any) error {
 	resp, err := s.HTTPClient.Do(req)
 	if err != nil {
 		return err

--- a/openai.go
+++ b/openai.go
@@ -88,6 +88,7 @@ func (s *Session) setHeaders(req *http.Request, contentType string) {
 	}
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Add("User-Agent", userAgent)
+}
 
 func (s *Session) sendRequest(req *http.Request, output any) error {
 	resp, err := s.HTTPClient.Do(req)

--- a/openai_test.go
+++ b/openai_test.go
@@ -1,0 +1,93 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitSession(t *testing.T) {
+	s := NewSession("test")
+	require.NotNil(t, s, "you must set an API key")
+}
+
+func TestMakeRequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusCode  int
+		apiKey      string
+		input       any
+		output      any
+		expectError bool
+	}{
+		{
+			name:        "success",
+			statusCode:  http.StatusOK,
+			apiKey:      "test-key",
+			input:       map[string]string{"hello": "world"},
+			output:      &struct{ Foo string }{},
+			expectError: false,
+		},
+		{
+			name:        "error:empty_api_key",
+			statusCode:  http.StatusUnauthorized,
+			apiKey:      "",
+			input:       map[string]string{"hello": "world"},
+			output:      &struct{ Foo string }{},
+			expectError: true,
+		},
+		{
+			name:        "error:nil_input",
+			statusCode:  http.StatusOK,
+			apiKey:      "test-key",
+			input:       nil,
+			output:      &struct{ Foo string }{},
+			expectError: true,
+		},
+		{
+			name:        "error:invalid_output",
+			statusCode:  http.StatusInternalServerError,
+			apiKey:      "test-key",
+			input:       map[string]string{"hello": "world"},
+			output:      &struct{ Foo int }{},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Helper()
+
+			mockServer := httpMockServer(tt.statusCode)
+			defer mockServer.Close()
+
+			// Create a new session with a test API key and the mock server's HTTP client.
+			session := &Session{
+				apiKey:     tt.apiKey,
+				HTTPClient: mockServer.Client(),
+			}
+
+			// Make the request.
+			err := session.MakeRequest(context.Background(), mockServer.URL, tt.input, tt.output)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+}
+
+func httpMockServer(statusCode int) *httptest.Server {
+	// Set up a mock server that returns a response with the given status code.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(statusCode)
+		w.Write([]byte(`{"foo": "bar"}`))
+	})
+
+	return httptest.NewServer(handler)
+}


### PR DESCRIPTION
This PR adds unit tests for the **NewSession** and **MakeRequest** methods in **openai.go** to ensure that they work as expected. 

Minor refactor: the sendRequest method has been split into two separate methods.