### PR TITLE
correct CreateCompletionParams top_p json name

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -43,7 +43,7 @@ type CreateCompletionParams struct {
 	Stream   bool       `json:"stream,omitempty"`
 
 	N           int     `json:"n,omitempty"`
-	TopP        float64 `json:"top_n,omitempty"`
+	TopP        float64 `json:"top_p,omitempty"`
 	Temperature float64 `json:"temperature,omitempty"`
 	MaxTokens   int     `json:"max_tokens,omitempty"`
 


### PR DESCRIPTION
This PR will correct the **top_p** request field name in the **CreateCompletionParams** model to ensure the mapping is correct with JSON.

Closes #10 