### PR TITLE
Correct TopP json tag and add example for edit

### DIFF
--- a/completion/completion.go
+++ b/completion/completion.go
@@ -44,7 +44,7 @@ type CreateParams struct {
 
 	MaxTokens   int     `json:"max_tokens,omitempty"`
 	N           int     `json:"n,omitempty"`
-	TopP        float64 `json:"top_n,omitempty"`
+	TopP        float64 `json:"top_p,omitempty"`
 	Temperature float64 `json:"temperature,omitempty"`
 
 	LogProbs         int     `json:"logprobs,omitempty"`

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -36,7 +36,7 @@ type CreateParams struct {
 	Instruction string `json:"instruction,omitempty"`
 
 	N           int     `json:"n,omitempty"`
-	TopP        float64 `json:"top_n,omitempty"`
+	TopP        float64 `json:"top_p,omitempty"`
 	Temperature float64 `json:"temperature,omitempty"`
 }
 

--- a/examples/edit/main.go
+++ b/examples/edit/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/rakyll/openai-go"
+	"github.com/rakyll/openai-go/edit"
+)
+
+func main() {
+	ctx := context.Background()
+	s := openai.NewSession(os.Getenv("OPENAI_API_KEY"))
+
+	client := edit.NewClient(s, "text-davinci-edit-001")
+	resp, err := client.Create(ctx, &edit.CreateParams{
+		N:           1,
+		Input:       "What day of the wek is it?",
+		Instruction: "Fix the spelling mistakes",
+	})
+	if err != nil {
+		log.Fatalf("Failed to create an edit: %v", err)
+	}
+
+	for _, choice := range resp.Choices {
+		log.Println(choice.Text)
+	}
+}


### PR DESCRIPTION
- Rename TopP json tag from top_n to top_p for both edit and completion CreateParams.
- Example for edit is added.

**Note**
OpenAI api is returning model doesn't exists for both text-davinci-edit-001 and code-davinci-edit-001

> {
    "error": {
        "message": "The model: `text-davinci-edit-001` does not exist",
        "type": "invalid_request_error",
        "param": null,
        "code": "model_not_found"
    }
}