### PR TITLE
Add Name parameter for Message in CreateCompletionParams

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -69,6 +69,7 @@ type Choice struct {
 type Message struct {
 	Role    string `json:"role,omitempty"`
 	Content string `json:"content,omitempty"`
+	Name    string `json:"name,omitempty"`
 }
 
 func (c *Client) CreateCompletion(ctx context.Context, p *CreateCompletionParams) (*CreateCompletionResponse, error) {


### PR DESCRIPTION
`name` is an optional parameter described as: `The name of the user in a multi-user chat` [1]

\[1]: https://github.com/openai/openai-openapi/blob/master/openapi.yaml#L2299-L2301