### PR TITLE
Allow empty Content and Role

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -70,8 +70,8 @@ type Choice struct {
 }
 
 type Message struct {
-	Role    string `json:"role,omitempty"`
-	Content string `json:"content,omitempty"`
+	Role    string `json:"role"`
+	Content string `json:"content"`
 	Name    string `json:"name,omitempty"`
 }
 


### PR DESCRIPTION
These fields are required. Content is allowed to be empty. This behavior can be observed by trying to include a FunctionCall Message (see also #25) which has no Content. The API will reject it.

The OpenAPI specification for this type
(https://github.com/openai/openai-openapi/blob/e6277eabbbb5df1e90620e3657bb02da28dce460/openapi.yaml#L2195-L2197) shows the following:

```yaml
    ChatCompletionRequestMessage:
      properties:
        ...

        content:
          type: string
          nullable: true
          description: The contents of the message. `content` is required for all messages, and may be null for assistant messages with function calls.

      ...
      required:
        - role
        - content
```

I've confirmed experimentally it accepts empty strings as well.